### PR TITLE
[add] フェイクリポジトリを追加しようとしたが、HttpResponseはMockで返す必要がありそうなので一旦中断。

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -65,4 +65,9 @@ dependencies {
     //Hilt
     implementation "com.google.dagger:hilt-android:2.41"
     kapt "com.google.dagger:hilt-android-compiler:2.41"
+
+    // project build.gradle
+    mockito_kotlin_version = '4.0.0'
+    // module build.gradle
+    testImplementation "org.mockito.kotlin:mockito-kotlin:$mockito_kotlin_version"
 }

--- a/app/src/test/kotlin/jp/co/yumemi/android/code_check/repository/FakeApiRepository.kt
+++ b/app/src/test/kotlin/jp/co/yumemi/android/code_check/repository/FakeApiRepository.kt
@@ -1,0 +1,33 @@
+package jp.co.yumemi.android.code_check.repository
+
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import jp.co.yumemi.android.code_check.domain.model.api.IApiRepository
+import jp.co.yumemi.android.code_check.infrastracture.api.Result
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.onStart
+
+
+class FakeApiRepository : IApiRepository {
+
+    var getActivityWasCalled = false
+
+    override suspend fun getHttpResponse(inputText: String): Flow<Result<HttpResponse>> {
+        getActivityWasCalled = true
+        return flow {
+            val result = try {
+                //成功した場合、結果を返す
+                Result.Success(data = )
+            } catch (e: Throwable) {
+                //失敗した場合、エラーメッセージを返す
+                Result.Error(exception = e)
+            }
+            emit(result)
+        }.onStart {
+            //開始時にロードを通知する
+            emit(Result.Process)
+        }
+    }
+}


### PR DESCRIPTION
https://maxkim.eu/full-guide-to-testing-android-applications-in-2022

この記事を参考にFakeリポジトリを追加しようとしたが、HttpResponseのサンプル戻り値を定義できなかったため中断。
Mockで返す必要がありそうだが、APIの操作がめんどくさいのでRetrofitに変更することにした。
