### PR TITLE
Feature/add/history jetpack

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,7 +49,7 @@ dependencies {
 
     implementation 'androidx.core:core-ktx:1.6.0'
     implementation 'androidx.appcompat:appcompat:1.3.1'
-    implementation 'com.google.android.material:material:1.4.0'
+    implementation 'com.google.android.material:material:1.6.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.1'
     implementation 'androidx.recyclerview:recyclerview:1.2.1'
 

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/infrastracture/room/HistoryDatabase.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/infrastracture/room/HistoryDatabase.kt
@@ -2,10 +2,9 @@ package jp.co.yumemi.android.code_check.infrastracture.room
 
 import androidx.room.Database
 import androidx.room.RoomDatabase
-import jp.co.yumemi.android.code_check.domain.model.item.Item
 
 
-@Database(entities = [Item::class], version = 1, exportSchema = false)
+@Database(entities = [History::class], version = 1, exportSchema = false)
 abstract class HistoryDatabase: RoomDatabase() {
     abstract fun historyDAO(): HistoryDAO
 }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/infrastracture/room/HistoryEntity.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/infrastracture/room/HistoryEntity.kt
@@ -2,13 +2,16 @@ package jp.co.yumemi.android.code_check.infrastracture.room
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
-import jp.co.yumemi.android.code_check.domain.model.item.Content
 
-class HistoryEntity {
-}
-
-@Entity
+@Entity(tableName = "history")
 data class History(
     @PrimaryKey(autoGenerate = true)
-    val history: Content
+    val id: Int?,
+    val name: String,
+    val avatarUrl: String,
+    val language: String?,
+    val stargazersCount: Long,
+    val watchersCount: Long,
+    val forksCount: Long,
+    val openIssuesCount: Long,
 ) {}

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/history/HistoryScreen.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/history/HistoryScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.material.Icon
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -17,16 +18,17 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import jp.co.yumemi.android.code_check.R
 
-@Preview
 @Composable
-fun HistoryScreen(names: List<String> = List(1000) {"test"}) {
+fun HistoryScreen(historyViewModel: HistoryViewModel) {
     val scrollState = rememberLazyListState()
     val coroutineScope = rememberCoroutineScope()
+
+    val historyList = historyViewModel.historyList.collectAsState()
     
     Scaffold(modifier = Modifier.fillMaxSize()) {
        LazyColumn() {
-         items(items = names) { name ->
-             itemCard(name)
+         items(items = historyList.value) { history ->
+             itemCard(history.name)
          }
        }
     }

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/history/HistoryViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/history/HistoryViewModel.kt
@@ -1,0 +1,38 @@
+package jp.co.yumemi.android.code_check.ui.history
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import jp.co.yumemi.android.code_check.domain.model.history.IHistoryRepository
+import jp.co.yumemi.android.code_check.infrastracture.room.DBResult
+import jp.co.yumemi.android.code_check.infrastracture.room.History
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+class HistoryViewModel @Inject constructor(
+    private val historyRepository: IHistoryRepository,
+) : ViewModel() {
+    private val _historyList = MutableStateFlow<List<History>>(emptyList())
+    val historyList: StateFlow<List<History>> get() = _historyList
+
+    fun fetchHistoryList() {
+        viewModelScope.launch {
+            historyRepository.getAll().onEach { result ->
+                when(result) {
+                    is DBResult.Process, is DBResult.Empty -> {
+
+                    }
+                    is DBResult.Error -> {
+
+                    }
+                    is DBResult.Success -> {
+                        _historyList.emit(result.data)
+                    }
+                }
+            }.launchIn(viewModelScope)
+        }
+    }
+}

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/history/HistoryViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/history/HistoryViewModel.kt
@@ -18,7 +18,11 @@ class HistoryViewModel @Inject constructor(
     private val _historyList = MutableStateFlow<List<History>>(emptyList())
     val historyList: StateFlow<List<History>> get() = _historyList
 
-    fun fetchHistoryList() {
+    init {
+        fetchHistoryList()
+    }
+
+    private fun fetchHistoryList() {
         viewModelScope.launch {
             historyRepository.getAll().onEach { result ->
                 when(result) {

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/search/SearchFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/search/SearchFragment.kt
@@ -14,10 +14,12 @@ import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
+import com.google.android.material.composethemeadapter.MdcTheme
 import dagger.hilt.android.AndroidEntryPoint
 import jp.co.yumemi.android.code_check.R
 import jp.co.yumemi.android.code_check.databinding.FragmentOneBinding
 import jp.co.yumemi.android.code_check.domain.model.item.ParcelizeItem
+import jp.co.yumemi.android.code_check.ui.history.HistoryScreen
 
 @AndroidEntryPoint
 class SearchFragment : Fragment(R.layout.fragment_one) {
@@ -44,13 +46,24 @@ class SearchFragment : Fragment(R.layout.fragment_one) {
             }
         })
 
+        //historyScreenをセット
+        binding.history.setContent {
+            MdcTheme {
+                HistoryScreen()
+            }
+        }
+
         //EditTextを制御
         binding.searchInputText
             .setOnEditorActionListener { editText, action, _ ->
+                //履歴を表示
+                binding.history.visibility = View.VISIBLE
                 //エラーメッセージを削除
                 binding.errorTextView.visibility = View.GONE
                 //ENTERが押された時の処理
                 if (action == EditorInfo.IME_ACTION_SEARCH) {
+                    //履歴一覧を非表示
+                    binding.history.visibility = View.GONE
                     editText.text.toString().let {
                         //submitListに入力された文字を代入
                         viewModel.searchResults(it)

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/search/SearchFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/search/SearchFragment.kt
@@ -20,10 +20,12 @@ import jp.co.yumemi.android.code_check.R
 import jp.co.yumemi.android.code_check.databinding.FragmentOneBinding
 import jp.co.yumemi.android.code_check.domain.model.item.ParcelizeItem
 import jp.co.yumemi.android.code_check.ui.history.HistoryScreen
+import jp.co.yumemi.android.code_check.ui.history.HistoryViewModel
 
 @AndroidEntryPoint
 class SearchFragment : Fragment(R.layout.fragment_one) {
     private val viewModel: SearchViewModel by viewModels()
+    private val historyViewModel: HistoryViewModel by viewModels()
     private var _binding: FragmentOneBinding? = null
     private val binding get() = _binding!!
 
@@ -49,7 +51,7 @@ class SearchFragment : Fragment(R.layout.fragment_one) {
         //historyScreenをセット
         binding.history.setContent {
             MdcTheme {
-                HistoryScreen()
+                HistoryScreen(historyViewModel)
             }
         }
 

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/search/SearchFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/search/SearchFragment.kt
@@ -7,11 +7,13 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.inputmethod.EditorInfo
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
-import androidx.recyclerview.widget.*
+import androidx.recyclerview.widget.DividerItemDecoration
+import androidx.recyclerview.widget.LinearLayoutManager
 import dagger.hilt.android.AndroidEntryPoint
 import jp.co.yumemi.android.code_check.R
 import jp.co.yumemi.android.code_check.databinding.FragmentOneBinding
@@ -44,17 +46,18 @@ class SearchFragment : Fragment(R.layout.fragment_one) {
 
         //EditTextを制御
         binding.searchInputText
-            .setOnEditorActionListener { editText, _, _ ->
+            .setOnEditorActionListener { editText, action, _ ->
                 //エラーメッセージを削除
                 binding.errorTextView.visibility = View.GONE
                 //ENTERが押された時の処理
-
+                if (action == EditorInfo.IME_ACTION_SEARCH) {
                     editText.text.toString().let {
                         //submitListに入力された文字を代入
                         viewModel.searchResults(it)
                     }
                     return@setOnEditorActionListener true
-
+                }
+                return@setOnEditorActionListener false
             }
 
         //liveDataで検索結果を監視

--- a/app/src/main/res/layout/fragment_one.xml
+++ b/app/src/main/res/layout/fragment_one.xml
@@ -88,5 +88,13 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="@+id/errorTextView" />
 
+        <androidx.compose.ui.platform.ComposeView
+            android:id="@+id/history"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="@+id/errorTextView"/>
+
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/fragment_one.xml
+++ b/app/src/main/res/layout/fragment_one.xml
@@ -64,6 +64,7 @@
             android:layout_height="0dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.0"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/searchBar" />
 


### PR DESCRIPTION
roomからhistoryを取得して、表示するまでの一連の流れを実装。

履歴一覧はcomposeで実装
fragment上に<androidx.compose.ui.platform.ComposeView>を追加し、
```
binding.history.setContent {
            MdcTheme {
                HistoryScreen(historyViewModel)
            }
        }
```
で読み込み。

editTextがactiveになったら表示、enterが押されたら非表示と切り替えた。

